### PR TITLE
feature/plugin updates 20122021

### DIFF
--- a/plugins.yaml
+++ b/plugins.yaml
@@ -4,19 +4,19 @@ plugins:
       version: 0.5.6
   - artifactId: configuration-as-code-secret-ssm
     source:
-        version: 1.0.1
+      version: 1.0.1
   - artifactId: pipeline-aws
     source:
-        version: 1.43
+      version: 1.43
   - artifactId: pipeline-utility-steps
     source:
-        version: 2.11.0
+      version: 2.11.0
   - artifactId: job-dsl
     source:
       version: 1.78.1
   - artifactId: jobConfigHistory
     source:
-      version: 2.28.1
+      version: 2.30
   - artifactId: artifact-manager-s3
     source:
       version: 1.16.1
@@ -24,7 +24,7 @@ plugins:
     source:
       version: 1.15.1
   - artifactId: role-strategy
-    source: 
+    source:
       version: 3.2.0
   - artifactId: audit-trail
     source:
@@ -58,16 +58,16 @@ plugins:
       version: 1.13
   - artifactId: nodejs
     source:
-      version: 1.4.2
+      version: 1.4.3
   - artifactId: electricflow
     source:
       version: 1.1.24
   - artifactId: bitbucket-oauth
     source:
-      version: 0.10
+      version: 0.12
   - artifactId: warnings-ng
     source:
-      version: 9.9.0
+      version: 9.10.2
   - artifactId: timestamper
     source:
       version: 1.15
@@ -85,7 +85,7 @@ plugins:
       version: 1.25.2
   - artifactId: github-oauth
     source:
-      version: 0.35
+      version: 0.36
   - artifactId: gitlab-oauth
     source:
       version: 1.12
@@ -151,7 +151,7 @@ plugins:
       version: 1.3.0
   - artifactId: email-ext
     source:
-      version: 2.85
+      version: 2.86
   - artifactId: s3
     source:
       version: 0.12.1
@@ -163,7 +163,7 @@ plugins:
       version: 1.25.2
   - artifactId: parameterized-trigger
     source:
-      version: 2.42
+      version: 2.43
   - artifactId: secure-requester-whitelist
     source:
       version: 1.6
@@ -181,7 +181,7 @@ plugins:
       version: 1.1.1
   - artifactId: matrix-auth
     source:
-      version: 2.6.8
+      version: 3.0
   - artifactId: basic-branch-build-strategies
     source:
       version: 1.3.2

--- a/plugins.yaml
+++ b/plugins.yaml
@@ -26,9 +26,6 @@ plugins:
   - artifactId: role-strategy
     source: 
       version: 3.2.0
-  - artifactId: bitbucket-oauth
-    source:
-      version: 0.10
   - artifactId: audit-trail
     source:
       version: 3.10
@@ -44,9 +41,6 @@ plugins:
   - artifactId: scm-filter-branch-pr
     source:
       version: 0.5.1
-  - artifactId: multibranch-build-strategy-extension
-    source:
-      version: 1.0.10
   - artifactId: deployer-framework
     source:
       version: 1.3
@@ -68,9 +62,6 @@ plugins:
   - artifactId: electricflow
     source:
       version: 1.1.24
-  - artifactId: job-dsl
-    source:
-      version: 1.77
   - artifactId: bitbucket-oauth
     source:
       version: 0.10
@@ -104,9 +95,6 @@ plugins:
   - artifactId: unique-id
     source:
       version: 2.2.0
-  - artifactId: artifact-manager-s3
-    source:
-      version: 1.15
   - artifactId: ssh-slaves
     source:
       version: 1.33.0
@@ -143,9 +131,6 @@ plugins:
   - artifactId: external-monitor-job
     source:
       version: 1.7
-  - artifactId: scm-filter-branch-pr
-    source:
-      version: 0.5.1
   - artifactId: build-timeout
     source:
       version: 1.20
@@ -197,9 +182,6 @@ plugins:
   - artifactId: matrix-auth
     source:
       version: 2.6.8
-  - artifactId: extended-read-permission
-    source:
-      version: 3.2
   - artifactId: basic-branch-build-strategies
     source:
       version: 1.3.2


### PR DESCRIPTION
- remove duplicate plugins

# bump plugin versions

jobConfigHistory (2.28.1) -> 2.30
nodejs (1.4.2) -> 1.4.3
bitbucket-oauth (0.10) -> 0.12
warnings-ng (9.9.0) -> 9.10.2
github-oauth (0.35) -> 0.36
email-ext (2.85) -> 2.86
parameterized-trigger (2.42) -> 2.43
matrix-auth (2.6.8) -> 3.0