### PR TITLE
add plugin dependencies to fix cycle in plugin dependencies

### DIFF
--- a/plugins.yaml
+++ b/plugins.yaml
@@ -135,6 +135,12 @@ plugins:
 - artifactId: "command-launcher"
   source:
     version: "90.v669d7ccb_7c31"
+- artifactId: "commons-lang3-api"
+  source: 
+    version: "3.12.0-36.vd97de6465d5b_"
+- artifactId: "commons-text-api"
+  source:
+    version: "1.10.0-27.vb_fa_3896786a_7"
 - artifactId: "config-file-provider"
   source:
     version: "3.11.1"
@@ -333,6 +339,12 @@ plugins:
 - artifactId: "maven-plugin"
   source:
     version: "3.20"
+- artifactId: "mina-sshd-api-core"
+  source:
+    version: "2.9.1-44.v476733c11f82"
+- artifactId: "mina-sshd-api-common"
+  source:
+    version: "2.9.1-44.v476733c11f82"
 - artifactId: "momentjs"
   source:
     version: "1.1.1"


### PR DESCRIPTION
add plugins
- commons-lang3-api
- commons-text-api
- mina-sshd-api-core
- mina-sshd-api-common

resolve error
```
SEVERE	hudson.PluginManager$1$3$2$1#reactOnCycle: 
found cycle in plugin dependencies: (root=Plugin:ssh-credentials, deactivating all involved) 
Plugin:ssh-credentials -> Plugin:credentials -> Plugin:configuration-as-code -> Plugin:commons-text-api -> Plugin:commons-lang3-api -> Plugin:sshd -> Plugin:mina-sshd-api-core -> Plugin:ssh-credentials
```